### PR TITLE
🔧 Fix PWA icon errors - Disable PWA temporarily

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,14 +3,17 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import './styles.css'
-// Register PWA Service Worker (optional; works when plugin is installed)
+// PWA Service Worker temporarily disabled - missing icon files
+// TODO: Re-enable after adding proper PWA icons
+/*
 if ('serviceWorker' in navigator) {
-  import(/* @vite-ignore */ 'virtual:pwa-register')
+  import('virtual:pwa-register')
     .then(({ registerSW }) => {
       try { registerSW({ immediate: true }) } catch {}
     })
     .catch(() => {})
 }
+*/
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,31 +5,8 @@ import { VitePWA } from 'vite-plugin-pwa'
 export default defineConfig({
   plugins: [
     react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      manifest: {
-        name: 'EcoSoil',
-        short_name: 'EcoSoil',
-        start_url: '/',
-        display: 'standalone',
-        background_color: '#ffffff',
-        theme_color: '#1976d2',
-        icons: [
-          { src: '/icon-192.png', sizes: '192x192', type: 'image/png' },
-          { src: '/icon-512.png', sizes: '512x512', type: 'image/png' },
-        ],
-      },
-      workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
-        runtimeCaching: [
-          {
-            urlPattern: ({ url }) => url.pathname.startsWith('/api/'),
-            handler: 'NetworkFirst',
-            options: { cacheName: 'api-cache', networkTimeoutSeconds: 5 },
-          },
-        ],
-      },
-    }),
+    // PWA temporarily disabled - missing icon files
+    // VitePWA will be re-enabled after adding proper icons
   ],
   server: {
     host: true, // listen on 0.0.0.0 for LAN access


### PR DESCRIPTION
- Disable VitePWA plugin until proper icons are added
- Comment out PWA service worker registration
- Remove generated manifest files causing icon errors
- Fix build errors related to virtual:pwa-register
- Frontend now builds successfully without PWA warnings